### PR TITLE
Embed sslkeylog files into pcaps

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build Wireshark
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: |
-          cmake -GNinja -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=0 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DENABLE_STATIC=1 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 .
+          cmake -GNinja -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=1 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DENABLE_STATIC=1 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 .
           ninja
       - run: run/tshark -v
         if: steps.restore-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
With pcapng it is possible to embed the secrets from sslkeylog directly into the trace using `editcap`. This makes it easier when you want to analyze the pcap files (e.g. using Wireshark).