### PR TITLE
Include the test status in the log message when a test completes

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -430,7 +430,12 @@ class InteropRunner:
         server_log_dir.cleanup()
         client_log_dir.cleanup()
         sim_log_dir.cleanup()
-        logging.debug("Test took %ss", (datetime.now() - start_time).total_seconds())
+        logging.debug(
+            "Test: %s took %ss, status: %s",
+            str(testcase),
+            (datetime.now() - start_time).total_seconds(),
+            str(status),
+        )
 
         # measurements also have a value
         if hasattr(testcase, "result"):


### PR DESCRIPTION
When running all interop tests (without specific test selection)

```console
python run.py -c ... -s ...
```
the interop runner logs messages when a test completes. The log looks something like:

```console
Test: transfercorruption took 31.123s
```
Given that the entire run can take a long time to complete, I have found that including the test's status in the log message to be useful. That way I don't have to wait for entire run or try to search for other log messages to understand which tests failed and which ones passed so far.

The change in this PR proposes to include the test's status in this above log message when a test completes. So the log would now look like:

```console
Test: transfercorruption took 31.123s, status: TestResult.SUCCEEDED
```

Does this look like a change that can be accepted into this upstream repo?