### PR TITLE
fix key_phase bit check in captured packets

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -927,7 +927,7 @@ class TestCaseKeyUpdate(TestCaseHandshake):
 
             def _get_key_phase(pkt) -> int:
                 kp: str = pkt.key_phase.raw_value
-                # when key_phase bit is set in a Quic packet, certain versions
+                # when key_phase bit is set in a QUIC packet, certain versions
                 # of wireshark (4.0.11, for example) have been seen to return the string value
                 # "1" and certain other versions of wireshark return the string value "True".
                 # here we deal with such values and return the integer value 1 for either of those.


### PR DESCRIPTION
Hello Marten @marten-seemann, I was running the key update test today and I noticed that it no longer works and the test always fails on my setup. It looks like the issue is just related to the parsing of the captured packets and appears to have been caused by the changes in https://github.com/quic-interop/quic-interop-runner/pull/332.

The commit in this PR introduces a way to retain that newly introduced change as well as retain the older way, by allowing both the values "1" and "True" to be considered as key phase 1. With this change, the test now passes for me locally.

Perhaps @tatsuhiro-t too might want to give this change a try?