### PR TITLE
remove s2n-quic due to unreasonable AWS rate limits

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -74,11 +74,6 @@
     "url": "https://github.com/quinn-rs/quinn",
     "role": "both"
   },
-  "s2n-quic": {
-    "image": "public.ecr.aws/s2n/s2n-quic-qns:latest",
-    "url": "https://github.com/aws/s2n-quic",
-    "role": "both"
-  },
   "go-x-net": {
     "image": "us-central1-docker.pkg.dev/golang-interop-testing/quic/go-x-net:latest",
     "url": "https://pkg.go.dev/golang.org/x/net/internal/quic",


### PR DESCRIPTION
See #320.

I really don't want to do this, but AWS' docker registry is just completely broken. Requiring authentication to pull 3 times within a 24 hour period is just ridiculous.

@WesleyRosenblum s2n-quic will be welcome to re-join the interop runner once they've resolved this issue, one way or the other.