### PR TITLE
Pull s2n-quic from DockerHub

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -75,7 +75,7 @@
     "role": "both"
   },
   "s2n-quic": {
-    "image": "public.ecr.aws/s2n/s2n-quic-qns:latest",
+    "image": "awss2n/s2n-quic-qns:latest",
     "url": "https://github.com/aws/s2n-quic",
     "role": "both"
   },


### PR DESCRIPTION
Updates the s2n-quic-qns image host to DockerHub.