### PR TITLE
fix(implementations): update neqo image to new repository

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -35,7 +35,7 @@
     "role": "both"
   },
   "neqo": {
-    "image": "neqoquic/neqo-qns:latest",
+    "image": "ghcr.io/mozilla/neqo-qns:latest",
     "url": "https://github.com/mozilla/neqo",
     "role": "both"
   },


### PR DESCRIPTION
Neqo's interop runner Docker image is now hosted on GitHub's container registry and continuously updated via a daily GitHub action.

See https://github.com/mozilla/neqo/issues/1552 for details.

//CC @martinthomson and @larseggert 