### PR TITLE
Update NGINX to GitHub Registry

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -40,7 +40,7 @@
     "role": "both"
   },
   "nginx": {
-    "image": "public.ecr.aws/nginx/nginx-quic-qns:latest",
+    "image": "ghcr.io/nginx/nginx-quic-qns:latest",
     "url": "https://quic.nginx.org/",
     "role": "server"
   },


### PR DESCRIPTION
NGINX QUIC interop image has moved to GitHub Registry, addressing issues related to AWS ECR rate limits encountered previously (referencing issue #345). cc @thresheek