### PR TITLE
reformat code using black

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -1233,9 +1233,11 @@ class TestCasePortRebinding(TestCaseTransfer):
         num_migrations = 0
         for p in tr_server:
             cur = (
-                getattr(p["ipv6"], "dst")
-                if "IPV6" in str(p.layers)
-                else getattr(p["ip"], "dst"),
+                (
+                    getattr(p["ipv6"], "dst")
+                    if "IPV6" in str(p.layers)
+                    else getattr(p["ip"], "dst")
+                ),
                 int(getattr(p["udp"], "dstport")),
             )
             if last is None:
@@ -1428,9 +1430,11 @@ class TestCaseConnectionMigration(TestCaseAddressRebinding):
         dcid = None
         for p in tr_client:
             cur = (
-                getattr(p["ipv6"], "src")
-                if "IPV6" in str(p.layers)
-                else getattr(p["ip"], "src"),
+                (
+                    getattr(p["ipv6"], "src")
+                    if "IPV6" in str(p.layers)
+                    else getattr(p["ip"], "src")
+                ),
                 int(getattr(p["udp"], "srcport")),
             )
             if last is None:


### PR DESCRIPTION
Apparently Python developers think it's okay to break other people's (CI) build by just changing the way the code formatter works. Combined with a lack of version pinning this leads to unexpected CI failures like https://github.com/quic-interop/quic-interop-runner/actions/runs/7698591583/job/20978213685.