### PR TITLE
ci: enforce a 45 minute timeout per test run

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -156,6 +156,7 @@ jobs:
     needs: [ wireshark, config, docker-pull-tools, docker-pull-images ]
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix: 


### PR DESCRIPTION
Some implementations have delayed the interop runner by hours recently (see #350). Most implementations take ~15 minutes to complete the full suite of tests, so a 45 minute timeout is really generous.

Documentation: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes