### PR TITLE
allow to explicitly pass a "run" query param to the results page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -72,6 +72,8 @@
       </a>
     </div>
 
+    <div id="run-selection-msg" align="center"></div>
+
     <h3 class="mt-5">Results Filter</h3>
 
     <div class="mt-2 row">

--- a/web/script.js
+++ b/web/script.js
@@ -283,7 +283,11 @@
         document.getElementById("run-selection-msg").innerHTML = errMsg;
         return;
       }
-      process(xhr.response);
+      var result = xhr.response;
+      var selectedRun = result.log_dir.replace("logs_", "");
+      var refresh = window.location.protocol + "//" + window.location.host + window.location.pathname + "?run=" + selectedRun;
+      window.history.pushState(null, null, refresh);
+      process(result);
       document.getElementsByTagName("body")[0].classList.remove("loading");
     };
     xhr.send();

--- a/web/script.js
+++ b/web/script.js
@@ -281,6 +281,8 @@
         var run = dir.replace("logs_", "");
         var errMsg = '<strong>Error: could not locate result for "' + run + '" run</strong>';
         document.getElementById("run-selection-msg").innerHTML = errMsg;
+        var refresh = window.location.protocol + "//" + window.location.host + window.location.pathname + "?run=" + run;
+        window.history.pushState(null, null, refresh);
         return;
       }
       var result = xhr.response;

--- a/web/script.js
+++ b/web/script.js
@@ -270,6 +270,7 @@
 
   function load(dir) {
     document.getElementsByTagName("body")[0].classList.add("loading");
+    document.getElementById("run-selection-msg").innerHTML = "";
     var xhr = new XMLHttpRequest();
     xhr.responseType = 'json';
     xhr.open('GET', 'logs/' + dir + '/result.json');
@@ -277,6 +278,9 @@
       if(xhr.readyState !== XMLHttpRequest.DONE) return;
       if(xhr.status !== 200) {
         console.log("Received status: ", xhr.status);
+        var run = dir.replace("logs_", "");
+        var errMsg = '<strong>Error: could not locate result for "' + run + '" run</strong>';
+        document.getElementById("run-selection-msg").innerHTML = errMsg;
         return;
       }
       process(xhr.response);
@@ -285,7 +289,16 @@
     xhr.send();
   }
 
-  load("latest");
+  var selectedRun = null;
+  var queryParams = (new URL(document.location)).searchParams;
+  if (queryParams.has("run") === true) {
+    // if the request used a specific run (like ?run=123), then
+    // load that specifc one
+    selectedRun = queryParams.get("run")
+    load("logs_" + selectedRun);
+  } else {
+    load("latest");
+  }
 
   // enable loading of old runs
   var xhr = new XMLHttpRequest();
@@ -308,6 +321,11 @@
       load(ev.currentTarget.value);
     });
     document.getElementById("available-runs").appendChild(s);
+    if (selectedRun != null) {
+      // just set the selected run, no need to trigger "change"
+      // event here
+      s.value = "logs_" + selectedRun;
+    }
   };
   xhr.send();
 })();


### PR DESCRIPTION
Hello Marten @marten-seemann, I don't know if this change is of interest, but I thought I will raise this PR. I found it hard to link to specific runs in our internal tests, so I decided to implement this and I find this to be useful.

The web page which displays the interop test results (like here https://interop.seemann.io/) has a drop down of test runs. The first selection in it is the latest run. 

Sometimes, it's useful to directly link to a specific run so that the selected run is what gets displayed. It's currently not possible to have a direct link to a specific run.

The commit in this PR proposes to introduce an optional `run` query param which can be used to specify the test run that has to be displayed. It can then be directly linked as `https://interop.seemann.io/?run=456`, where `456` is the run id and the page will display the `456` run results. Of course, the drop down will continue to be available and once the page is rendered, if necessary the user can change the selected run.