### PR TITLE
feat: print result symbol in addition to color

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -180,9 +180,9 @@ class InteropRunner:
         logging.info("Run took %s", datetime.now() - self._start_time)
 
         def get_letters(result):
-            return "".join(
+            return result.symbol() + "(" + ",".join(
                 [test.abbreviation() for test in cell if cell[test] is result]
-            )
+            ) + ")"
 
         if len(self._tests) > 0:
             t = prettytable.PrettyTable()

--- a/interop.py
+++ b/interop.py
@@ -180,9 +180,14 @@ class InteropRunner:
         logging.info("Run took %s", datetime.now() - self._start_time)
 
         def get_letters(result):
-            return result.symbol() + "(" + ",".join(
-                [test.abbreviation() for test in cell if cell[test] is result]
-            ) + ")"
+            return (
+                result.symbol()
+                + "("
+                + ",".join(
+                    [test.abbreviation() for test in cell if cell[test] is result]
+                )
+                + ")"
+            )
 
         if len(self._tests) > 0:
             t = prettytable.PrettyTable()

--- a/result.py
+++ b/result.py
@@ -5,3 +5,11 @@ class TestResult(Enum):
     SUCCEEDED = "succeeded"
     FAILED = "failed"
     UNSUPPORTED = "unsupported"
+
+    def symbol(self):
+        if self == TestResult.SUCCEEDED:
+            return "✓"
+        elif self == TestResult.FAILED:
+            return "✕"
+        elif self == TestResult.UNSUPPORTED:
+            return "?"


### PR DESCRIPTION
Previously the test abbreviation was printed in green, grey and red depending on the result. Colors are not available in all environments, e.g. when printing into a file.

This commit adds symbols in addition to colors.

```
+------+--------+
|      |  neqo  |
+------+--------+
| neqo | ✓(H,S) |
|      |  ?()   |
|      |  ✕(R)  |
+------+--------+
```

Any format works for me. Using parenthesis first came to mind.