### PR TITLE
feat: add --must-include flag

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -44,8 +44,7 @@ class InteropRunner:
     measurement_results = {}
     compliant = {}
     _implementations = {}
-    _servers = []
-    _clients = []
+    _client_server_pairs = []
     _tests = []
     _measurements = []
     _output = ""
@@ -55,8 +54,7 @@ class InteropRunner:
     def __init__(
         self,
         implementations: dict,
-        servers: List[str],
-        clients: List[str],
+        client_server_pairs: List[Tuple[str, str]],
         tests: List[testcases.TestCase],
         measurements: List[testcases.Measurement],
         output: str,
@@ -75,8 +73,7 @@ class InteropRunner:
         self._start_time = datetime.now()
         self._tests = tests
         self._measurements = measurements
-        self._servers = servers
-        self._clients = clients
+        self._client_server_pairs=client_server_pairs
         self._implementations = implementations
         self._output = output
         self._log_dir = log_dir
@@ -86,16 +83,11 @@ class InteropRunner:
         if os.path.exists(self._log_dir):
             sys.exit("Log dir " + self._log_dir + " already exists.")
         logging.info("Saving logs to %s.", self._log_dir)
-        for server in servers:
-            self.test_results[server] = {}
-            self.measurement_results[server] = {}
-            for client in clients:
-                self.test_results[server][client] = {}
-                for test in self._tests:
-                    self.test_results[server][client][test] = {}
-                self.measurement_results[server][client] = {}
-                for measurement in measurements:
-                    self.measurement_results[server][client][measurement] = {}
+        for client, server in client_server_pairs:
+            for test in self._tests:
+                self.test_results.setdefault(server, {}).setdefault(client, {}).setdefault(test, {})
+            for measurement in measurements:
+                self.measurement_results.setdefault(server, {}).setdefault(client, {}).setdefault(measurement, {})
 
     def _is_unsupported(self, lines: List[str]) -> bool:
         return any("exited with code 127" in str(line) for line in lines) or any(
@@ -188,15 +180,22 @@ class InteropRunner:
             t = prettytable.PrettyTable()
             t.hrules = prettytable.ALL
             t.vrules = prettytable.ALL
-            t.field_names = [""] + [name for name in self._servers]
-            for client in self._clients:
+            rows = {}
+            columns = {}
+            for (client, server) in self._client_server_pairs:
+                columns[server] = {}
+                row = rows.setdefault(client, {})
+                cell = self.test_results[server][client]
+                res = colored(get_letters(TestResult.SUCCEEDED), "green") + "\n"
+                res += colored(get_letters(TestResult.UNSUPPORTED), "grey") + "\n"
+                res += colored(get_letters(TestResult.FAILED), "red")
+                row[server] = res
+
+            t.field_names = [""] + [column for column, _ in columns.items()]
+            for client, results in rows.items():
                 row = [client]
-                for server in self._servers:
-                    cell = self.test_results[server][client]
-                    res = colored(get_letters(TestResult.SUCCEEDED), "green") + "\n"
-                    res += colored(get_letters(TestResult.UNSUPPORTED), "grey") + "\n"
-                    res += colored(get_letters(TestResult.FAILED), "red")
-                    row += [res]
+                for server, _ in columns.items():
+                    row += [results.setdefault(server, "")]
                 t.add_row(row)
             print(t)
 
@@ -204,43 +203,52 @@ class InteropRunner:
             t = prettytable.PrettyTable()
             t.hrules = prettytable.ALL
             t.vrules = prettytable.ALL
-            t.field_names = [""] + [name for name in self._servers]
-            for client in self._clients:
-                row = [client]
-                for server in self._servers:
-                    cell = self.measurement_results[server][client]
-                    results = []
-                    for measurement in self._measurements:
-                        res = cell[measurement]
-                        if not hasattr(res, "result"):
-                            continue
-                        if res.result == TestResult.SUCCEEDED:
-                            results.append(
-                                colored(
-                                    measurement.abbreviation() + ": " + res.details,
-                                    "green",
-                                )
+            t.field_names = [""]
+            rows = {}
+            columns = {}
+            for client, server in self._client_server_pairs:
+                columns[server] = {}
+                row = rows.setdefault(client, {})
+                cell = self.measurement_results[server][client]
+                results = []
+                for measurement in self._measurements:
+                    res = cell[measurement]
+                    if not hasattr(res, "result"):
+                        continue
+                    if res.result == TestResult.SUCCEEDED:
+                        results.append(
+                            colored(
+                                measurement.abbreviation() + ": " + res.details,
+                                "green",
                             )
-                        elif res.result == TestResult.UNSUPPORTED:
-                            results.append(colored(measurement.abbreviation(), "grey"))
-                        elif res.result == TestResult.FAILED:
-                            results.append(colored(measurement.abbreviation(), "red"))
-                    row += ["\n".join(results)]
+                        )
+                    elif res.result == TestResult.UNSUPPORTED:
+                        results.append(colored(measurement.abbreviation(), "grey"))
+                    elif res.result == TestResult.FAILED:
+                        results.append(colored(measurement.abbreviation(), "red"))
+                row[server] += "\n".join(results)
+            t.field_names = [""] + [column for column, _ in columns.items()]
+            for client, results in rows.items():
+                row = [client]
+                for server, _ in columns.items():
+                    row += [results.setdefault(server, "")]
                 t.add_row(row)
             print(t)
 
     def _export_results(self):
         if not self._output:
             return
+        clients = list(set(server for client, server in self._client_server_pairs))
+        servers = list(set(server for client, server in self._client_server_pairs))
         out = {
             "start_time": self._start_time.timestamp(),
             "end_time": datetime.now().timestamp(),
             "log_dir": self._log_dir,
-            "servers": [name for name in self._servers],
-            "clients": [name for name in self._clients],
+            "servers": servers,
+            "clients": clients,
             "urls": {
                 x: self._implementations[x]["url"]
-                for x in self._servers + self._clients
+                for x in clients + servers
             },
             "tests": {
                 x.abbreviation(): {
@@ -255,36 +263,35 @@ class InteropRunner:
             "measurements": [],
         }
 
-        for client in self._clients:
-            for server in self._servers:
-                results = []
-                for test in self._tests:
-                    r = None
-                    if hasattr(self.test_results[server][client][test], "value"):
-                        r = self.test_results[server][client][test].value
-                    results.append(
-                        {
-                            "abbr": test.abbreviation(),
-                            "name": test.name(),  # TODO: remove
-                            "result": r,
-                        }
-                    )
-                out["results"].append(results)
+        for client, server in self._client_server_pairs:
+            results = []
+            for test in self._tests:
+                r = None
+                if hasattr(self.test_results[server][client][test], "value"):
+                    r = self.test_results[server][client][test].value
+                results.append(
+                    {
+                        "abbr": test.abbreviation(),
+                        "name": test.name(),  # TODO: remove
+                        "result": r,
+                    }
+                )
+            out["results"].append(results)
 
-                measurements = []
-                for measurement in self._measurements:
-                    res = self.measurement_results[server][client][measurement]
-                    if not hasattr(res, "result"):
-                        continue
-                    measurements.append(
-                        {
-                            "name": measurement.name(),  # TODO: remove
-                            "abbr": measurement.abbreviation(),
-                            "result": res.result.value,
-                            "details": res.details,
-                        }
-                    )
-                out["measurements"].append(measurements)
+            measurements = []
+            for measurement in self._measurements:
+                res = self.measurement_results[server][client][measurement]
+                if not hasattr(res, "result"):
+                    continue
+                measurements.append(
+                    {
+                        "name": measurement.name(),  # TODO: remove
+                        "abbr": measurement.abbreviation(),
+                        "result": res.result.value,
+                        "details": res.details,
+                    }
+                )
+            out["measurements"].append(measurements)
 
         f = open(self._output, "w")
         json.dump(out, f)
@@ -479,33 +486,32 @@ class InteropRunner:
         """run the interop test suite and output the table"""
 
         nr_failed = 0
-        for server in self._servers:
-            for client in self._clients:
-                logging.debug(
-                    "Running with server %s (%s) and client %s (%s)",
-                    server,
-                    self._implementations[server]["image"],
-                    client,
-                    self._implementations[client]["image"],
-                )
-                if not (
-                    self._check_impl_is_compliant(server)
-                    and self._check_impl_is_compliant(client)
-                ):
-                    logging.info("Not compliant, skipping")
-                    continue
+        for client, server in self._client_server_pairs:
+            logging.debug(
+                "Running with server %s (%s) and client %s (%s)",
+                server,
+                self._implementations[server]["image"],
+                client,
+                self._implementations[client]["image"],
+            )
+            if not (
+                self._check_impl_is_compliant(server)
+                and self._check_impl_is_compliant(client)
+            ):
+                logging.info("Not compliant, skipping")
+                continue
 
-                # run the test cases
-                for testcase in self._tests:
-                    status = self._run_testcase(server, client, testcase)
-                    self.test_results[server][client][testcase] = status
-                    if status == TestResult.FAILED:
-                        nr_failed += 1
+            # run the test cases
+            for testcase in self._tests:
+                status = self._run_testcase(server, client, testcase)
+                self.test_results[server][client][testcase] = status
+                if status == TestResult.FAILED:
+                    nr_failed += 1
 
-                # run the measurements
-                for measurement in self._measurements:
-                    res = self._run_measurement(server, client, measurement)
-                    self.measurement_results[server][client][measurement] = res
+            # run the measurements
+            for measurement in self._measurements:
+                res = self._run_measurement(server, client, measurement)
+                self.measurement_results[server][client][measurement] = res
 
         self._print_results()
         self._export_results()

--- a/interop.py
+++ b/interop.py
@@ -73,7 +73,7 @@ class InteropRunner:
         self._start_time = datetime.now()
         self._tests = tests
         self._measurements = measurements
-        self._client_server_pairs=client_server_pairs
+        self._client_server_pairs = client_server_pairs
         self._implementations = implementations
         self._output = output
         self._log_dir = log_dir
@@ -85,9 +85,13 @@ class InteropRunner:
         logging.info("Saving logs to %s.", self._log_dir)
         for client, server in client_server_pairs:
             for test in self._tests:
-                self.test_results.setdefault(server, {}).setdefault(client, {}).setdefault(test, {})
+                self.test_results.setdefault(server, {}).setdefault(
+                    client, {}
+                ).setdefault(test, {})
             for measurement in measurements:
-                self.measurement_results.setdefault(server, {}).setdefault(client, {}).setdefault(measurement, {})
+                self.measurement_results.setdefault(server, {}).setdefault(
+                    client, {}
+                ).setdefault(measurement, {})
 
     def _is_unsupported(self, lines: List[str]) -> bool:
         return any("exited with code 127" in str(line) for line in lines) or any(
@@ -182,7 +186,7 @@ class InteropRunner:
             t.vrules = prettytable.ALL
             rows = {}
             columns = {}
-            for (client, server) in self._client_server_pairs:
+            for client, server in self._client_server_pairs:
                 columns[server] = {}
                 row = rows.setdefault(client, {})
                 cell = self.test_results[server][client]
@@ -246,10 +250,7 @@ class InteropRunner:
             "log_dir": self._log_dir,
             "servers": servers,
             "clients": clients,
-            "urls": {
-                x: self._implementations[x]["url"]
-                for x in clients + servers
-            },
+            "urls": {x: self._implementations[x]["url"] for x in clients + servers},
             "tests": {
                 x.abbreviation(): {
                     "name": x.name(),

--- a/run.py
+++ b/run.py
@@ -65,6 +65,11 @@ def main():
         parser.add_argument(
             "-j", "--json", help="output the matrix to file in json format"
         )
+        parser.add_argument(
+            "-i",
+            "--must-include",
+            help="implementation that must be included",
+        )
         return parser.parse_args()
 
     replace_arg = get_args().replace
@@ -86,6 +91,14 @@ def main():
             if s not in availableImpls:
                 sys.exit(role + " implementation " + s + " not found.")
             impls.append(s)
+        return impls
+
+    def get_impl_pairs(clients, servers, must_include) -> List[Tuple[str, str]]:
+        impls = []
+        for client in clients:
+            for server in servers:
+                if must_include is None or client == must_include or server == must_include:
+                    impls.append((client, server))
         return impls
 
     def get_tests_and_measurements(
@@ -124,8 +137,7 @@ def main():
     t = get_tests_and_measurements(get_args().test)
     return InteropRunner(
         implementations=implementations,
-        servers=get_impls(get_args().server, server_implementations, "Server"),
-        clients=get_impls(get_args().client, client_implementations, "Client"),
+        client_server_pairs=get_impl_pairs(get_impls(get_args().client, client_implementations, "Client"), get_impls(get_args().server, server_implementations, "Server"),  get_args().must_include),
         tests=t[0],
         measurements=t[1],
         output=get_args().json,

--- a/run.py
+++ b/run.py
@@ -97,7 +97,11 @@ def main():
         impls = []
         for client in clients:
             for server in servers:
-                if must_include is None or client == must_include or server == must_include:
+                if (
+                    must_include is None
+                    or client == must_include
+                    or server == must_include
+                ):
                     impls.append((client, server))
         return impls
 
@@ -137,7 +141,11 @@ def main():
     t = get_tests_and_measurements(get_args().test)
     return InteropRunner(
         implementations=implementations,
-        client_server_pairs=get_impl_pairs(get_impls(get_args().client, client_implementations, "Client"), get_impls(get_args().server, server_implementations, "Server"),  get_args().must_include),
+        client_server_pairs=get_impl_pairs(
+            get_impls(get_args().client, client_implementations, "Client"),
+            get_impls(get_args().server, server_implementations, "Server"),
+            get_args().must_include,
+        ),
         tests=t[0],
         measurements=t[1],
         output=get_args().json,


### PR DESCRIPTION
Introduce new command line flag `--must-include`.

When running the QUIC Interop Runner in CI of a single implementation, one is only interested in test pairs including that particular implementation. As an example, take a world with 3 QUIC implementations, quic-go, ngtcp2 and neqo. On the neqo CI one is not interested in the client-server pair quic-go->ngtcp2.

With this commit one can specify `--must-include neqo` on neqo's CI.

```
$ python3 run.py --test handshake --must-include neqo

Saving logs to logs_2024-02-24T17:39:08.
Server: neqo. Client: quic-go. Running test case: handshake
Server: neqo. Client: ngtcp2. Running test case: handshake
Server: quic-go. Client: neqo. Running test case: handshake
Server: ngtcp2. Client: neqo. Running test case: handshake
Server: neqo. Client: neqo. Running test case: handshake
Run took 0:01:50.070133
+---------+------+---------+--------+
|         | neqo | quic-go | ngtcp2 |
+---------+------+---------+--------+
| quic-go | ✓(H) |         |        |
|         | ?()  |         |        |
|         | ✕()  |         |        |
+---------+------+---------+--------+
|  ngtcp2 | ✓(H) |         |        |
|         | ?()  |         |        |
|         | ✕()  |         |        |
+---------+------+---------+--------+
|   neqo  | ✓(H) |   ✓(H)  |  ✓(H)  |
|         | ?()  |   ?()   |  ?()   |
|         | ✕()  |   ✕()   |  ✕()   |
+---------+------+---------+--------+
```

---

Before I polish the actual implementation, @marten-seemann can you give this a high level review? Detailed comments are appreciated but not yet necessary.