### PR TITLE
ci: clean up old runs on the server

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,42 @@
+name: cleanup
+on:
+  schedule:
+  - cron: "0 */8 * * *" # every 8h
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old logs on the server
+        uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1
+        with:
+          host: interop.seemann.io
+          username: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
+          key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
+          script: |
+            delete_oldest_folder() {
+                OLDEST_DIR=$(find "${{ vars.LOG_DIR }}" -mindepth 1 -maxdepth 1 -type d -printf '%T+ %p\n' | sort | head -n 1 | cut -d" " -f2-)
+                if [[ -n "$OLDEST_DIR" ]]; then
+                    echo "Deleting oldest directory: $OLDEST_DIR"
+                    rm -rf "$OLDEST_DIR"
+                fi
+            }
+
+            # Loop until enough space is available or no directories left to delete
+            while true; do
+                AVAILABLE_SPACE_GB=$(df -BG "${{ vars.LOG_DIR }}" | tail -n 1 | awk '{print $4}' | sed 's/G//')
+                echo "Available Space: $AVAILABLE_SPACE_GB GB"
+
+                if [[ "$AVAILABLE_SPACE_GB" -lt 50 ]]; then
+                    echo "Less than 50 GB available. Trying to clean up..."
+                    delete_oldest_folder
+                else
+                    echo "Enough space available."
+                    break
+                fi
+            done
+
+            TEMP_FILE=$(mktemp)
+            find "${{ vars.LOG_DIR }}" -mindepth 1 -maxdepth 1 -type d -not -name 'lost+found' -exec basename {} \; | sort > "$TEMP_FILE"
+            jq -R -s 'split("\n") | map(select(. != ""))' "$TEMP_FILE" > "${{ vars.LOG_DIR }}/logs.json"
+            rm -f "$TEMP_FILE"

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,7 +1,9 @@
 name: interop
 on:
   schedule:
-  - cron: "0 */8 * * *" # every 8h
+   # Every 8h, at 15 minutes past the hour
+   # This makes sure that the cleanup cron job can run first.
+  - cron: "15 */8 * * *"
 
 # Cache key for caching the Wireshark build.
 # To trigger a rebuild of Wireshark increment this value.
@@ -229,7 +231,7 @@ jobs:
         with:
           switches: -avzr --relative
           path: logs/./${{ matrix.server }}_${{ matrix.client }}/
-          remote_path: /mnt/logs/${{ needs.config.outputs.logname }}
+          remote_path: ${{ vars.LOG_DIR }}/${{ needs.config.outputs.logname }}
           remote_host: interop.seemann.io
           remote_user: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           remote_key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
@@ -276,7 +278,7 @@ jobs:
         with:
           switches: -avzr
           path: result.json
-          remote_path: /mnt/logs/${{ needs.config.outputs.logname }}/
+          remote_path: ${{ vars.LOG_DIR }}/${{ needs.config.outputs.logname }}/
           remote_host: interop.seemann.io
           remote_user: ${{ secrets.INTEROP_SEEMANN_IO_USER }}
           remote_key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
@@ -289,7 +291,7 @@ jobs:
           key: ${{ secrets.INTEROP_SEEMANN_IO_SSH_KEY }}
           envs: LOGNAME
           script: |
-            cd /mnt/logs
+            cd ${{ vars.LOG_DIR }}
             jq '. += [ "${{ needs.config.outputs.logname }}" ]' logs.json | sponge logs.json
             rm latest || true
             ln -s $LOGNAME latest


### PR DESCRIPTION
We need to clean up old log files on interop.seemann.io, otherwise we'll run out of hard disk space. This is what has been happening the last couple of weeks, and is the reason the interop runner was stopped.

Previously, this cleanup was done by a cron job on interop.seemann.io, but it was lost when I migrated the server to a different cloud provider. By moving the cleanup logic into a GitHub Action in this repository, we reduce the complexity required on the server side, which should make it easier to migrate it again in the future.