### PR TITLE
Update mvfst interop image

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -10,7 +10,7 @@
     "role": "both"
   },
   "mvfst": {
-    "image": "lnicco/mvfst-qns:latest",
+    "image": "ghcr.io/facebook/proxygen/mvfst-interop:latest",
     "url": "https://github.com/facebookincubator/mvfst",
     "role": "both"
   },


### PR DESCRIPTION
This switches the mvfst interop image to one that is published using a Github workflow:
https://github.com/facebook/proxygen/blob/v2024.03.25.00/.github/workflows/publish_mvfst_interop.yml

This image is updated weekly.