### PR TITLE
fix(interop.py): override instead of append to row[server]

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -240,7 +240,7 @@ class InteropRunner:
                         results.append(colored(measurement.abbreviation(), "grey"))
                     elif res.result == TestResult.FAILED:
                         results.append(colored(measurement.abbreviation(), "red"))
-                row[server] += "\n".join(results)
+                row[server] = "\n".join(results)
             t.field_names = [""] + [column for column, _ in columns.items()]
             for client, results in rows.items():
                 row = [client]


### PR DESCRIPTION
Previously when calculating each cell of the _measurements_ result table, instead of always setting a cell, a cell would be appended in case one already existed. Appending a cell to another doesn't make sense in this context. In addition this code also errors, given that on the first cell `row[server] +=` results in a `KeyError`.

```
 Traceback (most recent call last):
  File "run.py", line 168, in <module>
    sys.exit(main())
  File "run.py", line 150, in main
    return InteropRunner(
  File "/home/runner/work/quic-go/quic-go/quic-interop-runner/interop.py", line 529, in run
    self._print_results()
  File "/home/runner/work/quic-go/quic-go/quic-interop-runner/interop.py", line 243, in _print_results
    row[server] += "\n".join(results)
KeyError: 'quic-go-latest'
```

See e.g. https://github.com/quic-go/quic-go/actions/runs/8159188951/job/23046885072.

This commit fixes the above simply by setting the cell, not appending it for the case where one already exists.

Bug introduced in https://github.com/quic-interop/quic-interop-runner/pull/355