### PR TITLE
updating s2n-quic image to GitHub Container Repository

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -75,7 +75,7 @@
     "role": "both"
   },
   "s2n-quic": {
-    "image": "awss2n/s2n-quic-qns:latest",
+    "image": "ghcr.io/aws/s2n-quic/s2n-quic-qns:latest",
     "url": "https://github.com/aws/s2n-quic",
     "role": "both"
   },


### PR DESCRIPTION
This change updates the [s2n-quic image](https://github.com/aws/s2n-quic/pkgs/container/s2n-quic%2Fs2n-quic-qns) to pull from GitHub Container Repository instead of Docker Hub