### PR TITLE
feat: optional measurements markdown table

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -215,6 +215,8 @@ class InteropRunner:
 
         if len(self._measurements) > 0:
             t = prettytable.PrettyTable()
+            if self._markdown:
+                t.set_style(prettytable.MARKDOWN)
             t.hrules = prettytable.ALL
             t.vrules = prettytable.ALL
             t.field_names = [""]


### PR DESCRIPTION
Previously when providing `--markdown` flag, only the tests table would be formatted in Markdown format.

With this patch, both the tests and the measurements table are formatted using markdown.

---

Follow-up to https://github.com/quic-interop/quic-interop-runner/pull/372/.