### PR TITLE
fix(interop/measurements): don't initialize t.field_names

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -217,7 +217,6 @@ class InteropRunner:
             t = prettytable.PrettyTable()
             t.hrules = prettytable.ALL
             t.vrules = prettytable.ALL
-            t.field_names = [""]
             rows = {}
             columns = {}
             for client, server in self._client_server_pairs:


### PR DESCRIPTION
Previously, when printing the measurements result table, one would initialize the `t.field_names` field to `[""]`. Later on `t.field_names` would be overwritten by the actual table column names, namely the servers under test.

Each time one sets `t.field_names`, the `field_names` setter logic would run.

https://github.com/jazzband/prettytable/blob/1f156f8f82a8442fcec332018de0d66fa308acce/src/prettytable/prettytable.py#L605-L608

Among this is `validate_field_names`, which asserts that the number of fields from the second assignment equals the number of fields of the first assignment.

https://github.com/jazzband/prettytable/blob/1f156f8f82a8442fcec332018de0d66fa308acce/src/prettytable/prettytable.py#L411-L421

Initializing `t.field_names` with `[""]` is not neccessary. Thus, to prevent the above assertion from failing, this commit removes the initialization, fully depending on the actual assignment with the name of the servers under test.

---

Uff, wasn't aware of Python's property decorators.

Bug introduced by me in https://github.com/quic-interop/quic-interop-runner/pull/355. Sorry about that.

Spotted by @WesleyRosenblum in https://github.com/quic-interop/quic-interop-runner/pull/375#issuecomment-2033388324. Thanks!