### PR TITLE
Maintain the right order of client/server while exporting the results to JSON

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -306,35 +306,36 @@ class InteropRunner:
             "measurements": [],
         }
 
-        for client, server in self._client_server_pairs:
-            results = []
-            for test in self._tests:
-                r = None
-                if hasattr(self.test_results[server][client][test], "value"):
-                    r = self.test_results[server][client][test].value
-                results.append(
-                    {
-                        "abbr": test.abbreviation(),
-                        "name": test.name(),  # TODO: remove
-                        "result": r,
-                    }
-                )
-            out["results"].append(results)
+        for client in clients:
+            for server in servers:
+                results = []
+                for test in self._tests:
+                    r = None
+                    if hasattr(self.test_results[server][client][test], "value"):
+                        r = self.test_results[server][client][test].value
+                    results.append(
+                        {
+                            "abbr": test.abbreviation(),
+                            "name": test.name(),  # TODO: remove
+                            "result": r,
+                        }
+                    )
+                out["results"].append(results)
 
-            measurements = []
-            for measurement in self._measurements:
-                res = self.measurement_results[server][client][measurement]
-                if not hasattr(res, "result"):
-                    continue
-                measurements.append(
-                    {
-                        "name": measurement.name(),  # TODO: remove
-                        "abbr": measurement.abbreviation(),
-                        "result": res.result.value,
-                        "details": res.details,
-                    }
-                )
-            out["measurements"].append(measurements)
+                measurements = []
+                for measurement in self._measurements:
+                    res = self.measurement_results[server][client][measurement]
+                    if not hasattr(res, "result"):
+                        continue
+                    measurements.append(
+                        {
+                            "name": measurement.name(),  # TODO: remove
+                            "abbr": measurement.abbreviation(),
+                            "result": res.result.value,
+                            "details": res.details,
+                        }
+                    )
+                out["measurements"].append(measurements)
 
         f = open(self._output, "w")
         json.dump(out, f)


### PR DESCRIPTION
This should fix the issue noted in https://github.com/quic-interop/quic-interop-runner/issues/390. 

The root cause of this issue that the in the change here https://github.com/quic-interop/quic-interop-runner/pull/355, we introduced the use of a `set()` for clients and servers https://github.com/quic-interop/quic-interop-runner/pull/355/files#diff-a1f0ac428938a846f118f59aa8e2e66b90bff7b498b928204eb3bfcb41f1f528R245, which cause the clients/servers to be potentially in a different order than the iteration order that we use later a few lines below https://github.com/quic-interop/quic-interop-runner/pull/355/files#diff-a1f0ac428938a846f118f59aa8e2e66b90bff7b498b928204eb3bfcb41f1f528R267.

The commit in this PR, addresses that by changing the iteration logic to iterate in the same order as that of the `clients`, `servers` that were constructed as a `set()`. I have triggered a interop run on my system to verify this actually fixes the issue. I will check out the results tomorrow.