### PR TITLE
Disable auto-unsupported test result classification when only one client or one server is involved

### DIFF
--- a/interop.py
+++ b/interop.py
@@ -180,6 +180,10 @@ class InteropRunner:
     def _postprocess_results(self):
         clients = list(set(client for client, _ in self._client_server_pairs))
         servers = list(set(server for _, server in self._client_server_pairs))
+        if not (len(clients) > 1 and len(servers) > 1):
+            # "auto unsupported" test-result classification is only applicable when there's more than
+            # one server and more than one client
+            return
         # If a client failed a test against all servers, make the test unsupported for the client
         questionable = [TestResult.FAILED, TestResult.UNSUPPORTED]
         for c in set(clients) - set(self._no_auto_unsupported):


### PR DESCRIPTION
I run the quic-interop-runner with 1 particular client against several servers. In such a scenario, a recent change in the quic-interop-runner causes any failures against any of the servers to be marked as "unsupported" instead of actually marking the failed test as a "failure".

Several such failures went undetected until I realized that the reporting was hiding the actual failure. I even attempted `--no-auto-supported <foo-bar-client>` when launching the runner. But that had no affect since the way it's currently implemented, when it compares a server failure against clients, the implementation considers that as a failure against all clients (since there's only one) and marks the result as unsupported.

I think this auto unsupported feature should only be applicable when there's more than one server and more than one client involved, to be sure that it fails against all of them. In this PR I have introduced a check to enable this feature only when there's more than one server and more than one client. With this change, in my test runs, the failures are now correctly reported.

Lars @larseggert, could you also review this change and see if this change will continue to allow your use cases to work as expected?