### PR TITLE
Add openssl docker image for interop testing

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -83,5 +83,10 @@
     "image": "us-central1-docker.pkg.dev/golang-interop-testing/quic/go-x-net:latest",
     "url": "https://pkg.go.dev/golang.org/x/net/internal/quic",
     "role": "both"
+  },
+  "openssl": {
+    "image": "quay.io/openssl-ci/openssl-quic-interop",
+    "url": "https://github.com/openssl/openssl",
+    "role": "client"
   }
 }


### PR DESCRIPTION
Thank you for all your great interop work

Add OpenSSL to the interop test matrix.