### PR TITLE
Fix FileNotFoundError thrown after editcap is run

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -177,7 +177,7 @@ class TestCase(abc.ABC):
             logging.debug("%s", r.stdout.decode("utf-8"))
             if r.returncode != 0:
                 return
-            shutil.move(tmp.name, trace)
+            shutil.copyfile(tmp.name, trace)
 
     def _client_trace(self):
         if self._cached_client_trace is None:


### PR DESCRIPTION
Recently started seeing this error show up while running all test cases:

...
Using the client's key log file.

testcase.check() threw FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpdxoaw2r4'
Test: http3 took 13.500148s, status: TestResult.FAILED

This error occurs with all interop test cases and client/server combinations for me that make use of the recorded pcap files from said test cases

Tracking down the problem, it appears to be a combination of recent commit 8063219 and the behavior of the NamedTemporaryFile class in python

In the referenced commit, the interop runner executes editcap on an input pcap file, stores output to an allocated NamedTemporaryFile, and then moves the latter back to the former.

The problem occurs when the function returns, and the NamedTemporaryFile goes out of scope.  When that happens, the temp file closer executes to remove the temporary file, but because shtutil.move has already unlinked the file, temp file closer function throws a FileNotFoundError, causing the test to abort.

I'm guessing there was a change in NamedTemporaryFile behavior that triggers this (i.e. it may not occur in older cpython implementations).

Given that we want the file to be unlinked automatically, it seems the best approach to fix this is to convert the shutil.move call to shtuil.copyfile, which preforms the same operation, but leaves the temp file in place such that the closer operation can clean it up itself.

tested on my local install successfully