### PR TITLE
fix: Always inject the keylog file into the pcaps

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -163,8 +163,10 @@ class TestCase(abc.ABC):
         """
         Inject the keylog file into the pcap file if it is available and valid.
         """
+        logging.info("Injecting keylog file into %s", trace)
         keylog = self._keylog_file()
         if keylog is None:
+            logging.info("No keylog file available.")
             return
 
         with tempfile.NamedTemporaryFile() as tmp:
@@ -302,6 +304,8 @@ class TestCase(abc.ABC):
 
     @abc.abstractmethod
     def check(self) -> TestResult:
+        self._client_trace()
+        self._server_trace()
         pass
 
 
@@ -338,6 +342,7 @@ class TestCaseVersionNegotiation(TestCase):
         return [""]
 
     def check(self) -> TestResult:
+        super().check()
         tr = self._client_trace()
         initials = tr.get_initial(Direction.FROM_CLIENT)
         dcid = ""
@@ -373,6 +378,7 @@ class TestCaseHandshake(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         if not self._check_version_and_files():
             return TestResult.FAILED
         if self._retry_sent():
@@ -408,6 +414,7 @@ class TestCaseLongRTT(TestCaseHandshake):
         return "simple-p2p --delay=750ms --bandwidth=10Mbps --queue=25"
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -453,6 +460,7 @@ class TestCaseTransfer(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -484,6 +492,7 @@ class TestCaseChaCha20(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -528,6 +537,7 @@ class TestCaseMultiplexing(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -609,6 +619,7 @@ class TestCaseRetry(TestCase):
         return False
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -641,6 +652,7 @@ class TestCaseResumption(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -702,6 +714,7 @@ class TestCaseZeroRTT(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 2:
             logging.info("Expected exactly 2 handshakes. Got: %d", num_handshakes)
@@ -744,6 +757,7 @@ class TestCaseHTTP3(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -787,6 +801,7 @@ class TestCaseAmplificationLimit(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -898,6 +913,7 @@ class TestCaseBlackhole(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -931,6 +947,7 @@ class TestCaseKeyUpdate(TestCaseHandshake):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -1026,6 +1043,7 @@ class TestCaseHandshakeLoss(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != self._num_runs:
             logging.info(
@@ -1065,6 +1083,7 @@ class TestCaseTransferLoss(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)
@@ -1144,6 +1163,7 @@ class TestCaseECN(TestCaseHandshake):
         return False
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -1227,6 +1247,7 @@ class TestCasePortRebinding(TestCaseTransfer):
         return "rebind --delay=15ms --bandwidth=10Mbps --queue=25 --first-rebind=1s --rebind-freq=5s"
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -1330,6 +1351,7 @@ class TestCaseAddressRebinding(TestCasePortRebinding):
         )
 
     def check(self) -> TestResult:
+        super().check()
         if not self._keylog_file():
             logging.info("Can't check test result. SSLKEYLOG required.")
             return TestResult.UNSUPPORTED
@@ -1388,6 +1410,7 @@ class TestCaseIPv6(TestCaseTransfer):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         result = super(TestCaseIPv6, self).check()
         if result != TestResult.SUCCEEDED:
             return result
@@ -1433,6 +1456,7 @@ class TestCaseConnectionMigration(TestCaseAddressRebinding):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         # The parent check() method ensures that the client changed addresses
         # and that PATH_CHALLENGE/RESPONSE frames were sent and received
         result = super(TestCaseConnectionMigration, self).check()
@@ -1496,6 +1520,7 @@ class TestCaseV2(TestCase):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         # Client should initially send QUIC v1 packet.  It may send
         # QUIC v2 packet.
         versions = self._get_packet_versions(
@@ -1599,6 +1624,7 @@ class MeasurementGoodput(Measurement):
         return self._files
 
     def check(self) -> TestResult:
+        super().check()
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)


### PR DESCRIPTION
Before, they would only get injected when `check()` used `_client_trace()` or `_server_trace()`. Not all testcases called both of these, so some pcaps remained without keylog files.