### PR TITLE
Don't check for retry in handshake test

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -379,9 +379,6 @@ class TestCaseHandshake(TestCase):
         super().check()
         if not self._check_version_and_files():
             return TestResult.FAILED
-        if self._retry_sent():
-            logging.info("Didn't expect a Retry to be sent.")
-            return TestResult.FAILED
         num_handshakes = self._count_handshakes()
         if num_handshakes != 1:
             logging.info("Expected exactly 1 handshake. Got: %d", num_handshakes)


### PR DESCRIPTION
The test checks for retries, but according to RFC 9000 s. 8.1, a server may send a retry packet to preform address validation on the client.  If the server does this the trace will show a retry packet, and doing so appears valid

easiest fix seems to simply be to allow retry packets to be present in the test