### PR TITLE
fix: Don't require multiple addresses for CM testcases

### DIFF
--- a/testcases.py
+++ b/testcases.py
@@ -1424,7 +1424,7 @@ class TestCaseIPv6(TestCaseTransfer):
         return TestResult.SUCCEEDED
 
 
-class TestCaseConnectionMigration(TestCaseAddressRebinding):
+class TestCaseConnectionMigration(TestCasePortRebinding):
     @staticmethod
     def name():
         return "connectionmigration"


### PR DESCRIPTION
Inherit from `TestCasePortRebinding` rather than `TestCaseAddressRebinding`.

Fixes #419