### PR TITLE
ignore non-QUIC packets in trace analysis (#421)

### DIFF
--- a/trace.py
+++ b/trace.py
@@ -113,6 +113,9 @@ class TraceAnalyzer:
         # See https://github.com/KimiNewt/pyshark/issues/390.
         try:
             for p in cap:
+                if "quic" not in p:
+                    logging.info("Captured packet without quic layer: %r", p)
+                    continue
                 packets.append(p)
             cap.close()
         except Exception as e:


### PR DESCRIPTION
Non-QUIC packet can slip through in certain cases.
This change is to log the message instead of crashing whole test.