### PR TITLE
Add quic-zig implementation (QUIC + WebTransport)

### DIFF
--- a/implementations_quic.json
+++ b/implementations_quic.json
@@ -83,5 +83,10 @@
     "image": "us-central1-docker.pkg.dev/golang-interop-testing/quic/go-x-net:latest",
     "url": "https://pkg.go.dev/golang.org/x/net/internal/quic",
     "role": "both"
+  },
+  "quic-zig": {
+    "image": "ghcr.io/endel/quic-zig:latest",
+    "url": "https://github.com/endel/quic-zig",
+    "role": "both"
   }
 }

--- a/implementations_webtransport.json
+++ b/implementations_webtransport.json
@@ -18,5 +18,10 @@
     "image": "peterdoornbosch/flupke-webtransport-interop",
     "url": "https://github.com/ptrd/flupke",
     "role": "server"
+  },
+  "quic-zig": {
+    "image": "ghcr.io/endel/quic-zig:latest",
+    "url": "https://github.com/endel/quic-zig",
+    "role": "both"
   }
 }


### PR DESCRIPTION
## Summary

Adds [quic-zig](https://github.com/endel/quic-zig) — a pure Zig QUIC implementation (RFC 9000/9001/9002) with HTTP/3 and WebTransport support. Zero C dependencies. Docker image auto-built via [GitHub Actions CI](https://github.com/endel/quic-zig/blob/main/.github/workflows/docker.yml) and published to `ghcr.io/endel/quic-zig:latest`.

The same Docker image serves both QUIC and WebTransport tests — the entrypoint script auto-detects WT mode and dispatches to dedicated WT server/client binaries.

## Supported QUIC test cases (self-interop)

| Test | Result |
|------|--------|
| handshake | :white_check_mark: |
| transfer | :white_check_mark: |
| retry | :white_check_mark: |
| http3 | :white_check_mark: |
| ecn | :white_check_mark: |
| multiplexing | :white_check_mark: |
| resumption | :white_check_mark: |
| zerortt | :white_check_mark: |
| keyupdate | :white_check_mark: |
| longrtt | :white_check_mark: |
| chacha20 | :white_check_mark: |
| ipv6 | :white_check_mark: |
| v2 | :white_check_mark: |
| transferloss | :white_check_mark: |
| transfercorruption | :white_check_mark: |
| amplificationlimit | :white_check_mark: |
| rebind-port | :white_check_mark: |
| rebind-addr | :white_check_mark: |
| blackhole | :x: |
| handshakeloss | :x: |
| handshakecorruption | :x: |
| connectionmigration | :x: |

18/22 QUIC test cases pass in self-interop.

## Supported WebTransport test cases (self-interop)

| Test | Abbr | Result |
|------|------|--------|
| handshake | H | :white_check_mark: |
| transfer-unidirectional-receive | UR | :white_check_mark: |
| transfer-unidirectional-send | US | :white_check_mark: |
| transfer-bidirectional-receive | BR | :white_check_mark: |
| transfer-bidirectional-send | BS | :white_check_mark: |
| transfer-datagram-receive | DR | :white_check_mark: |
| transfer-datagram-send | DS | :white_check_mark: |

7/7 WebTransport test cases pass in self-interop.

## Endpoint details

- **Dockerfile**: [`interop/runner/Dockerfile`](https://github.com/endel/quic-zig/blob/main/interop/runner/Dockerfile) — multi-stage build, extends `martenseemann/quic-network-simulator-endpoint:latest`
- **Entry point**: [`interop/runner/run_endpoint.sh`](https://github.com/endel/quic-zig/blob/main/interop/runner/run_endpoint.sh) — sources `/setup.sh`, dispatches on `$ROLE`, auto-detects WT mode via `$PROTOCOLS`
- **Image**: `ghcr.io/endel/quic-zig:latest` (linux/amd64)
- **Role**: both (client + server)
- **QLOG**: writes to `$QLOGDIR` when set
- **SSLKEYLOGFILE**: writes to `$SSLKEYLOGFILE` when set

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add quic-zig implementation entry for QUIC and WebTransport interop tests
> Registers `quic-zig` (image `ghcr.io/endel/quic-zig:latest`, role `both`) in [implementations_quic.json](https://github.com/quic-interop/quic-interop-runner/pull/491/files#diff-0c76a030d8e8cfb37c9b3536695477ec1d6758f30907140fd1c3f6cfa4815138) and [implementations_webtransport.json](https://github.com/quic-interop/quic-interop-runner/pull/491/files#diff-62ff908a0b1812c9d6280553f12e974fe96bf078ed933d6005f9af09405c807b) so it participates in both QUIC and WebTransport interop test matrices.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be7d83d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->